### PR TITLE
Pkg 3792: initial feedstock, v12.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,20 @@
+# The buildout of these CUDA packages is happening on a private channel for the moment,
+# while we wait for a redistribution license.
+# It also prevents uploading to our public staging channel.
+# The below can probably all be deleted next time the feedstock needs updating.
+
+channels:
+  - lc030263
+upload_channels:
+  - lc030263
+
+upload_to_staging_channel_in_pr: False
+
+upload_without_merge: True
+
+mark_private: True
+
+# don't skip existing
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,18 +3,14 @@
 # It also prevents uploading to our public staging channel.
 # The below can probably all be deleted next time the feedstock needs updating.
 
-channels:
+upload_channels:
   - lc030263
-# upload_channels:
-#   - lc030263
 
 upload_to_staging_channel_in_pr: False
 
-#upload_without_merge: True
+mark_private: True
 
-#mark_private: True
-
-# don't skip existing
+# don't skip existing, to update any existing packages
 # don't error overlinking (this should stay, see https://github.com/conda-forge/cuda-cudart-feedstock/pull/15)
 build_parameters:
   - "--suppress-variables"

--- a/abs.yaml
+++ b/abs.yaml
@@ -15,6 +15,6 @@ upload_without_merge: True
 mark_private: True
 
 # don't skip existing
-# build_parameters:
-#   - "--suppress-variables"
-#   - "--error-overlinking"
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,16 +3,16 @@
 # It also prevents uploading to our public staging channel.
 # The below can probably all be deleted next time the feedstock needs updating.
 
-channels:
-  - lc030263
-upload_channels:
-  - lc030263
+# channels:
+#   - lc030263
+# upload_channels:
+#   - lc030263
 
 upload_to_staging_channel_in_pr: False
 
-upload_without_merge: True
+#upload_without_merge: True
 
-mark_private: True
+#mark_private: True
 
 # don't skip existing
 # don't error overlinking (this should stay, see https://github.com/conda-forge/cuda-cudart-feedstock/pull/15)

--- a/abs.yaml
+++ b/abs.yaml
@@ -15,6 +15,6 @@ upload_without_merge: True
 mark_private: True
 
 # don't skip existing
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
+# build_parameters:
+#   - "--suppress-variables"
+#   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -15,6 +15,6 @@ upload_without_merge: True
 mark_private: True
 
 # don't skip existing
+# don't error overlinking (this should stay, see https://github.com/conda-forge/cuda-cudart-feedstock/pull/15)
 build_parameters:
   - "--suppress-variables"
-  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,8 +3,8 @@
 # It also prevents uploading to our public staging channel.
 # The below can probably all be deleted next time the feedstock needs updating.
 
-# channels:
-#   - lc030263
+channels:
+  - lc030263
 # upload_channels:
 #   - lc030263
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,6 +27,9 @@ for i in `ls`; do
 
                 if [[ $j =~ \.so\. ]]; then
                     patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
+                    # We want to remove runpath, otherwise it'll take precedence over rpath
+                    patchelf --set-runpath '' ${PREFIX}/${targetsDir}/$j
+
                 fi
             done
         fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 # Install to conda style directories
 [[ -d lib64 ]] && mv lib64 lib

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,9 +27,6 @@ for i in `ls`; do
 
                 if [[ $j =~ \.so\. ]]; then
                     patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
-                    # We want to remove runpath, otherwise it'll take precedence over rpath
-                    patchelf --set-runpath '' ${PREFIX}/${targetsDir}/$j
-
                 fi
             done
         fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,12 +24,9 @@ for i in `ls`; do
                 # Shared and static libraries are symlinked in $PREFIX/lib
                 ln -sv ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
 
-                # Conda-forge needs these .sos to find libraries in the environment, because
-                # the runtime dependencies are packaged in their ecosystem.
-                # For defaults, they're in the default system lib location.
-                # if [[ $j =~ \.so\. ]]; then
-                #     patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
-                # fi
+                if [[ $j =~ \.so\. ]]; then
+                    patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
+                fi
             done
         fi
     else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,9 +24,12 @@ for i in `ls`; do
                 # Shared and static libraries are symlinked in $PREFIX/lib
                 ln -sv ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
 
-                if [[ $j =~ \.so\. ]]; then
-                    patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
-                fi
+                # Conda-forge needs these .sos to find libraries in the environment, because
+                # the runtime dependencies are packaged in their ecosystem.
+                # For defaults, they're in the default system lib location.
+                # if [[ $j =~ \.so\. ]]; then
+                #     patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
+                # fi
             done
         fi
     else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -ex
 
 # Install to conda style directories
 [[ -d lib64 ]] && mv lib64 lib

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
+conda_glibc_ver:
+  - 2.17          # [not aarch64]
+  - 2.26          # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,16 +87,16 @@ outputs:
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
-      # requires:
-      #   - patchelf  # [linux]
-      # files:
-      #   - test-rpath.sh
+      requires:
+        - patchelf  # [linux]
+      files:
+        - test-rpath.sh
       commands:
         - test -L $PREFIX/lib/libcudart.so.{{ version.split(".")[0] }}                            # [linux]
         - test -L $PREFIX/lib/libcudart.so.{{ version }}                                          # [linux]
         - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version.split(".")[0] }}  # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version }}                # [linux]
-        # - bash test-rpath.sh                                                                      # [linux]
+        - bash test-rpath.sh                                                                      # [linux]
         - if not exist %LIBRARY_BIN%\cudart64_{{ version.split(".")[0] }}.dll exit 1              # [win]
 
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,7 @@ source:
 
 build:
   number: 0
-  #skip: true  # [osx or (linux and s390x)]
-  skip: true # [not win]
+  skip: true  # [osx or (linux and s390x)]
 
 outputs:
   - name: cuda-cudart_{{ target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
         - patchelf <0.18.0                      # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -77,7 +77,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
         - {{ pin_subpackage("cuda-cudart_" + target_platform, exact=True) }}
@@ -121,7 +121,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -163,7 +163,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -205,7 +205,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -239,7 +239,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -272,7 +272,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -305,7 +305,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx]
+  skip: true  # [osx or (linux and s390x)]
 
 outputs:
   - name: cuda-cudart_{{ target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,16 +87,16 @@ outputs:
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
-      requires:
-        - patchelf  # [linux]
-      files:
-        - test-rpath.sh
+      # requires:
+      #   - patchelf  # [linux]
+      # files:
+      #   - test-rpath.sh
       commands:
         - test -L $PREFIX/lib/libcudart.so.{{ version.split(".")[0] }}                            # [linux]
         - test -L $PREFIX/lib/libcudart.so.{{ version }}                                          # [linux]
         - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version.split(".")[0] }}  # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version }}                # [linux]
-        - bash test-rpath.sh                                                                      # [linux]
+        # - bash test-rpath.sh                                                                      # [linux]
         - if not exist %LIBRARY_BIN%\cudart64_{{ version.split(".")[0] }}.dll exit 1              # [win]
 
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx or (linux and s390x)]
+  #skip: true  # [osx or (linux and s390x)]
+  skip: true # [not win]
 
 outputs:
   - name: cuda-cudart_{{ target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
         - patchelf <0.18.0                      # [linux]
       host:
@@ -76,7 +76,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -120,7 +120,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -162,7 +162,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -204,7 +204,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -238,7 +238,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -271,7 +271,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -304,7 +304,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-3792](https://anaconda.atlassian.net/browse/PKG-3792) 

### Explanation of changes:

- Third package of CUDA 12.3 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Uploads to private anaconda.org channel because we don't have the license agreement for many of the packages in this buildout, including upstreams. (this particular package we have a license for)
- Also removes things that aren't applicable in defaults
  - binary patching to define $ORIGIN as runpath, as it's not needed because the patched binaries don't link against any conda-provided .sos (although I'm not sure why this was done in conda-forge either, [awaiting info](https://github.com/conda-forge/cuda-cudart-feedstock/issues/21))
  - adjust required glibc on aarch64, it's different between us and conda-forge


[PKG-3792]: https://anaconda.atlassian.net/browse/PKG-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ