### PR TITLE
Patch binaries with Rpath not runpath

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -8,8 +8,6 @@ upload_channels:
 
 upload_to_staging_channel_in_pr: False
 
-mark_private: True
-
 # don't skip existing, to update any existing packages
 # don't error overlinking (this should stay, see https://github.com/conda-forge/cuda-cudart-feedstock/pull/15)
 build_parameters:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,6 +25,8 @@ for i in `ls`; do
                 ln -sv ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
 
                 if [[ $j =~ \.so\. ]]; then
+                    # --force-rpath is added to reflect what conda-build does in other feedstocks; they just hadn't updated this one yet.
+                    # see https://github.com/conda-forge/cuda-cudart-feedstock/issues/21#issuecomment-1944420886
                     patchelf --set-rpath '$ORIGIN' --force-rpath ${PREFIX}/${targetsDir}/$j
                 fi
             done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,7 +25,7 @@ for i in `ls`; do
                 ln -sv ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
 
                 if [[ $j =~ \.so\. ]]; then
-                    patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
+                    patchelf --set-rpath '$ORIGIN' --force-rpath ${PREFIX}/${targetsDir}/$j
                 fi
             done
         fi


### PR DESCRIPTION
See https://github.com/conda-forge/cuda-cudart-feedstock/issues/21#issuecomment-1944420886 for explanation.

Note the build number doesn't need incrementing because it's not in defaults already.