### PR TITLE
cuda-cudart 12.8.90: Update to CUDA 12.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-# Required for glibc >= 2.28
-pkg_build_image_tag: main-rockylinux-8
-build_env_vars:
-  ANACONDA_ROCKET_GLIBC: "2.28"
-
-staging_channel_upload_target: cudatest
-channels:
-- https://staging.continuum.io/pbp/cudatest

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,8 @@
-# (the noarch packages contain the libraries)
-noarch_upload:
-  - linux-64
+# Required for glibc >= 2.28
+pkg_build_image_tag: main-rockylinux-8
+build_env_vars:
+  ANACONDA_ROCKET_GLIBC: "2.28"
 
+staging_channel_upload_target: cudatest
 channels:
-- sk_test
-upload_channels:
-- sk_test
-upload_without_merge: true
+- https://staging.continuum.io/pbp/cudatest

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,6 @@
-# without this, only the linux-64 noarch package will be uploaded
 # (the noarch packages contain the libraries)
 noarch_upload:
-  - all
+  - linux-64
 
 channels:
 - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,9 @@
 # (the noarch packages contain the libraries)
 noarch_upload:
   - all
+
+channels:
+- sk_test
+upload_channels:
+- sk_test
+upload_without_merge: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,6 @@ mkdir -p ${PREFIX}/lib/stubs
 [[ -d "$PREFIX/lib/pkgconfig" ]] && sed -E -i "s|cudaroot=.+|cudaroot=$PREFIX|g" $PREFIX/lib/pkgconfig/cuda*.pc
 
 [[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
-[[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
 # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html?highlight=tegra#cross-compilation
 [[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "sbsa" ]] && targetsDir="targets/sbsa-linux"
 #[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ mkdir -p ${PREFIX}/lib/stubs
 [[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
 # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html?highlight=tegra#cross-compilation
 [[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "sbsa" ]] && targetsDir="targets/sbsa-linux"
-#[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
 
 if [ -z "${targetsDir+x}" ]; then
     echo "target_platform: ${target_platform} is unknown! targetsDir must be defined!" >&2

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,14 @@ mkdir -p ${PREFIX}/lib/stubs
 
 [[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
 [[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
-[[ ${target_platform} == "linux-aarch64" ]] && targetsDir="targets/sbsa-linux"
+# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html?highlight=tegra#cross-compilation
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "sbsa" ]] && targetsDir="targets/sbsa-linux"
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
+
+if [ -z "${targetsDir+x}" ]; then
+    echo "target_platform: ${target_platform} is unknown! targetsDir must be defined!" >&2
+    exit 1
+fi
 
 for i in `ls`; do
     [[ $i == "build_env_setup.sh" ]] && continue
@@ -35,3 +42,5 @@ for i in `ls`; do
         cp -rv $i ${PREFIX}/${targetsDir}/${PKG_NAME}/$i
     fi
 done
+
+check-glibc ${PREFIX}/${targetsDir}/lib/*.so.*

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,7 @@ mkdir -p ${PREFIX}/lib/stubs
 [[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
 # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html?highlight=tegra#cross-compilation
 [[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "sbsa" ]] && targetsDir="targets/sbsa-linux"
-[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
+#[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
 
 if [ -z "${targetsDir+x}" ]; then
     echo "target_platform: ${target_platform} is unknown! targetsDir must be defined!" >&2

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,8 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+  # arm-variant * tegra requires glibc version which is currently not available.
+  # binary glibc 2.29.0 <= recipe glibc 2.28 $PREFIX/bin/nvcc
+  # The binary is not compatible with the recipe's glibc pinning.
+  # See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#system-requirements
+  # Enable this once glibc is available on the main channel.
+  #- tegra         # [aarch64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,3 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-conda_glibc_ver:
-  - 2.17          # [not aarch64]
-  - 2.26          # [aarch64]
+  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-cudart" %}
-{% set version = "12.8.57" %}
+{% set version = "12.8.90" %}
 {% set cuda_version = "12.8" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -20,10 +20,10 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/{{ platform }}/cuda_cudart-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 5bd3ac35ea8e8ab880e595d5054ee373abf6d9e53dcb8cef0a5c75358dbc0ae2  # [linux64]
-  sha256: b94814dacc8e4e69c8909ac08ae9f8d6831c1a141358a6e9f60583481a49ae2b  # [aarch64 and arm_variant_type=="sbsa"]
-  #sha256: 45a6f64522329448d75e9c6adcd625994fe85f6aff9befe0dd43468aa65cb00a  # [aarch64 and arm_variant_type=="tegra"]
-  sha256: 2c7aa62a195d79229d4381c8bd0174a30502cf3d8124c6e94ee50a7fc8a1e9f4  # [win]
+  sha256: 8d566b5fe745c46842dc16945cf36686227536decd2302c372be86da37faca68  # [linux64]
+  sha256: 9e54c6686b193efa9642e7f6609ce78b064c5d576946478bcff4c024e1acdea7  # [aarch64 and arm_variant_type=="sbsa"]
+  #sha256: 0cdde0058d47b3307bc2d58156cfadce092631a3d24616e1b88d6ef089b5ca73  # [aarch64 and arm_variant_type=="tegra"]
+  sha256: 4a39058fd8519444a81cfc7ae055d136f48d1a31ffa41ae255b35b2edd61e13b  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "cuda-cudart" %}
-{% set version = "12.4.127" %}
-{% set cuda_version = "12.4" %}
+{% set version = "12.8.57" %}
+{% set cuda_version = "12.8" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
-{% set platform = "linux-sbsa" %}  # [aarch64]
+{% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
+{% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
 {% set target_name = "ppc64le-linux" %}  # [ppc64le]
-{% set target_name = "sbsa-linux" %}  # [aarch64]
+{% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
+{% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
 {% set extension = "tar.xz" %}  # [not win]
 {% set extension = "zip" %}  # [win]
@@ -18,14 +20,20 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/{{ platform }}/cuda_cudart-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 0483bff9a36e7a44465db3cd42874f6f70f019297dcf803fbefcbf58d7448c8f  # [linux64]
-  sha256: f5e636944c7817b4f178070daa1259f25b3e84ebd092305d32aa189b21ae37e3  # [ppc64le]
-  sha256: fb96abcff3544384440b9259f9aeab9bf222a5775348546ef87c68ee02eee379  # [aarch64]
-  sha256: 6a1c32e68ee1a95ca17334691ff9ad1ffe7f352c24a083d55e4c96b8063b2bcb  # [win]
+  sha256: 5bd3ac35ea8e8ab880e595d5054ee373abf6d9e53dcb8cef0a5c75358dbc0ae2  # [linux64]
+  sha256: b94814dacc8e4e69c8909ac08ae9f8d6831c1a141358a6e9f60583481a49ae2b  # [aarch64 and arm_variant_type=="sbsa"]
+  sha256: 45a6f64522329448d75e9c6adcd625994fe85f6aff9befe0dd43468aa65cb00a  # [aarch64 and arm_variant_type=="tegra"]
+  sha256: 2c7aa62a195d79229d4381c8bd0174a30502cf3d8124c6e94ee50a7fc8a1e9f4  # [win]
 
 build:
   number: 0
-  skip: true  # [osx or (linux and s390x)]
+  skip: true  # [osx]
+
+requirements:
+  build:
+    - {{ stdlib("c") }}
+    - patchelf <0.18.0  # [linux]
+    - cf-nvidia-tools   # [linux]
 
 outputs:
   - name: cuda-cudart_{{ target_platform }}
@@ -39,14 +47,12 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
-        - patchelf <0.18.0                      # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -76,15 +82,14 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
         - {{ pin_subpackage("cuda-cudart_" + target_platform, exact=True) }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-cudart_" + target_platform, exact=True) }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       requires:
@@ -120,8 +125,8 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -129,7 +134,6 @@ outputs:
         - {{ pin_subpackage("cuda-cudart", exact=True) }}
         - {{ pin_subpackage("cuda-cudart-dev_" + target_platform, exact=True) }}
         - {{ pin_subpackage("cuda-cudart-static", exact=True) }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -162,8 +166,8 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -171,7 +175,6 @@ outputs:
         - cuda-cudart-static_{{ target_platform }}
         - cuda-cccl_{{ target_platform }}
         - cuda-cudart_{{ target_platform }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -204,14 +207,13 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("cuda-cudart-static_" + target_platform, exact=True) }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -238,13 +240,12 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -271,14 +272,13 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-driver-dev_{{ target_platform }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -304,13 +304,12 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}.*    # [linux]
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "cuda-cudart" %}
-{% set libname = "cudart" %}
 {% set version = "12.8.90" %}
 {% set cuda_version = "12.8" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
-#{% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
+{% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
-#{% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
+{% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
 {% set extension = "tar.xz" %}  # [not win]
 {% set extension = "zip" %}  # [win]
@@ -55,8 +54,8 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -L $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version.split(".")[0] }}  # [linux]
-        - test -f $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version }}                # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version.split(".")[0] }}  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version }}                # [linux]
         - if exist %LIBRARY_BIN%\cudart64_{{ version.split(".")[0] }}.dll exit 1                  # [win]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
@@ -76,7 +75,7 @@ outputs:
         - "*/api-ms-win-security-systemfunctions-*.dll"  # [win]
     files:
       - lib/libcu*.so.*                            # [linux]
-      - Library\bin\{{ libname }}*.dll                    # [win]
+      - Library\bin\cudart*.dll                    # [win]
     requirements:
       build:
         - {{ compiler("c") }}
@@ -99,10 +98,10 @@ outputs:
       files:
         - test-rpath.sh
       commands:
-        - test -L $PREFIX/lib/lib{{ libname }}.so.{{ version.split(".")[0] }}                            # [linux]
-        - test -L $PREFIX/lib/lib{{ libname }}.so.{{ version }}                                          # [linux]
-        - test -L $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version.split(".")[0] }}  # [linux]
-        - test -f $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version }}                # [linux]
+        - test -L $PREFIX/lib/libcudart.so.{{ version.split(".")[0] }}                            # [linux]
+        - test -L $PREFIX/lib/libcudart.so.{{ version }}                                          # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version.split(".")[0] }}  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version }}                # [linux]
         - bash test-rpath.sh                                                                      # [linux]
         - if not exist %LIBRARY_BIN%\cudart64_{{ version.split(".")[0] }}.dll exit 1              # [win]
 
@@ -139,9 +138,9 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -L $PREFIX/lib/lib{{ libname }}.so           # [linux]
+        - test -L $PREFIX/lib/libcudart.so           # [linux]
         - test -f $PREFIX/lib/pkgconfig/cuda-*.pc    # [linux]
-        - test -f $PREFIX/lib/pkgconfig/{{ libname }}-*.pc  # [linux]
+        - test -f $PREFIX/lib/pkgconfig/cudart-*.pc  # [linux]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE
@@ -163,7 +162,7 @@ outputs:
       - Library\include                                                 # [win]
       - Library\lib\cuda.lib                                            # [win]
       - Library\lib\cudadevrt.lib                                       # [win]
-      - Library\lib\{{ libname }}.lib                                          # [win]
+      - Library\lib\cudart.lib                                          # [win]
     requirements:
       build:
         - {{ compiler("c") }}
@@ -185,13 +184,13 @@ outputs:
         - test -f $PREFIX/targets/{{ target_name }}/include/cuda_runtime_api.h                  # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/include/cooperative_groups/memcpy_async.h   # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/include/cooperative_groups/details/async.h  # [linux]
-        - test -L $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so                            # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so                            # [linux]
         - if not exist %LIBRARY_INC%\cuda.h exit 1                                              # [win]
         - if not exist %LIBRARY_INC%\cuda_runtime.h exit 1                                      # [win]
         - if not exist %LIBRARY_INC%\cuda_runtime_api.h exit 1                                  # [win]
         - if not exist %LIBRARY_LIB%\cuda.lib exit 1                                            # [win]
         - if not exist %LIBRARY_LIB%\cudadevrt.lib exit 1                                       # [win]
-        - if not exist %LIBRARY_LIB%\{{ libname }}.lib exit 1                                          # [win]
+        - if not exist %LIBRARY_LIB%\cudart.lib exit 1                                          # [win]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE
@@ -219,7 +218,7 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -L $PREFIX/lib/lib{{ libname }}_static.a  # [linux]
+        - test -L $PREFIX/lib/libcudart_static.a  # [linux]
         - test -L $PREFIX/lib/libcudadevrt.a      # [linux]
         - test -L $PREFIX/lib/libculibos.a        # [linux]
     about:
@@ -237,7 +236,7 @@ outputs:
       noarch: generic
     files:
       - targets/{{ target_name }}/lib/*.a  # [linux]
-      - Library\lib\{{ libname }}_static.lib      # [win]
+      - Library\lib\cudart_static.lib      # [win]
     requirements:
       build:
         - {{ compiler("c") }}
@@ -251,10 +250,10 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -f $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}_static.a  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart_static.a  # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/lib/libcudadevrt.a      # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/lib/libculibos.a        # [linux]
-        - if not exist %LIBRARY_LIB%\{{ libname }}_static.lib exit 1               # [win]
+        - if not exist %LIBRARY_LIB%\cudart_static.lib exit 1               # [win]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,12 +4,12 @@
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
-{% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
+#{% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
 {% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
-{% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
+#{% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
 {% set extension = "tar.xz" %}  # [not win]
 {% set extension = "zip" %}  # [win]
@@ -22,7 +22,7 @@ source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/{{ platform }}/cuda_cudart-{{ platform }}-{{ version }}-archive.{{ extension }}
   sha256: 5bd3ac35ea8e8ab880e595d5054ee373abf6d9e53dcb8cef0a5c75358dbc0ae2  # [linux64]
   sha256: b94814dacc8e4e69c8909ac08ae9f8d6831c1a141358a6e9f60583481a49ae2b  # [aarch64 and arm_variant_type=="sbsa"]
-  sha256: 45a6f64522329448d75e9c6adcd625994fe85f6aff9befe0dd43468aa65cb00a  # [aarch64 and arm_variant_type=="tegra"]
+  #sha256: 45a6f64522329448d75e9c6adcd625994fe85f6aff9befe0dd43468aa65cb00a  # [aarch64 and arm_variant_type=="tegra"]
   sha256: 2c7aa62a195d79229d4381c8bd0174a30502cf3d8124c6e94ee50a7fc8a1e9f4  # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
 {% set name = "cuda-cudart" %}
+{% set libname = "cudart" %}
 {% set version = "12.8.90" %}
 {% set cuda_version = "12.8" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
 #{% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
 #{% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -56,8 +55,8 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version.split(".")[0] }}  # [linux]
-        - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version }}                # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version.split(".")[0] }}  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version }}                # [linux]
         - if exist %LIBRARY_BIN%\cudart64_{{ version.split(".")[0] }}.dll exit 1                  # [win]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
@@ -77,7 +76,7 @@ outputs:
         - "*/api-ms-win-security-systemfunctions-*.dll"  # [win]
     files:
       - lib/libcu*.so.*                            # [linux]
-      - Library\bin\cudart*.dll                    # [win]
+      - Library\bin\{{ libname }}*.dll                    # [win]
     requirements:
       build:
         - {{ compiler("c") }}
@@ -100,10 +99,10 @@ outputs:
       files:
         - test-rpath.sh
       commands:
-        - test -L $PREFIX/lib/libcudart.so.{{ version.split(".")[0] }}                            # [linux]
-        - test -L $PREFIX/lib/libcudart.so.{{ version }}                                          # [linux]
-        - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version.split(".")[0] }}  # [linux]
-        - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart.so.{{ version }}                # [linux]
+        - test -L $PREFIX/lib/lib{{ libname }}.so.{{ version.split(".")[0] }}                            # [linux]
+        - test -L $PREFIX/lib/lib{{ libname }}.so.{{ version }}                                          # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version.split(".")[0] }}  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so.{{ version }}                # [linux]
         - bash test-rpath.sh                                                                      # [linux]
         - if not exist %LIBRARY_BIN%\cudart64_{{ version.split(".")[0] }}.dll exit 1              # [win]
 
@@ -140,9 +139,9 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -L $PREFIX/lib/libcudart.so           # [linux]
+        - test -L $PREFIX/lib/lib{{ libname }}.so           # [linux]
         - test -f $PREFIX/lib/pkgconfig/cuda-*.pc    # [linux]
-        - test -f $PREFIX/lib/pkgconfig/cudart-*.pc  # [linux]
+        - test -f $PREFIX/lib/pkgconfig/{{ libname }}-*.pc  # [linux]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE
@@ -164,7 +163,7 @@ outputs:
       - Library\include                                                 # [win]
       - Library\lib\cuda.lib                                            # [win]
       - Library\lib\cudadevrt.lib                                       # [win]
-      - Library\lib\cudart.lib                                          # [win]
+      - Library\lib\{{ libname }}.lib                                          # [win]
     requirements:
       build:
         - {{ compiler("c") }}
@@ -186,13 +185,13 @@ outputs:
         - test -f $PREFIX/targets/{{ target_name }}/include/cuda_runtime_api.h                  # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/include/cooperative_groups/memcpy_async.h   # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/include/cooperative_groups/details/async.h  # [linux]
-        - test -L $PREFIX/targets/{{ target_name }}/lib/libcudart.so                            # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}.so                            # [linux]
         - if not exist %LIBRARY_INC%\cuda.h exit 1                                              # [win]
         - if not exist %LIBRARY_INC%\cuda_runtime.h exit 1                                      # [win]
         - if not exist %LIBRARY_INC%\cuda_runtime_api.h exit 1                                  # [win]
         - if not exist %LIBRARY_LIB%\cuda.lib exit 1                                            # [win]
         - if not exist %LIBRARY_LIB%\cudadevrt.lib exit 1                                       # [win]
-        - if not exist %LIBRARY_LIB%\cudart.lib exit 1                                          # [win]
+        - if not exist %LIBRARY_LIB%\{{ libname }}.lib exit 1                                          # [win]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE
@@ -220,7 +219,7 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -L $PREFIX/lib/libcudart_static.a  # [linux]
+        - test -L $PREFIX/lib/lib{{ libname }}_static.a  # [linux]
         - test -L $PREFIX/lib/libcudadevrt.a      # [linux]
         - test -L $PREFIX/lib/libculibos.a        # [linux]
     about:
@@ -238,7 +237,7 @@ outputs:
       noarch: generic
     files:
       - targets/{{ target_name }}/lib/*.a  # [linux]
-      - Library\lib\cudart_static.lib      # [win]
+      - Library\lib\{{ libname }}_static.lib      # [win]
     requirements:
       build:
         - {{ compiler("c") }}
@@ -252,10 +251,10 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -f $PREFIX/targets/{{ target_name }}/lib/libcudart_static.a  # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/lib{{ libname }}_static.a  # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/lib/libcudadevrt.a      # [linux]
         - test -f $PREFIX/targets/{{ target_name }}/lib/libculibos.a        # [linux]
-        - if not exist %LIBRARY_LIB%\cudart_static.lib exit 1               # [win]
+        - if not exist %LIBRARY_LIB%\{{ libname }}_static.lib exit 1               # [win]
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,6 +94,9 @@ outputs:
     test:
       requires:
         - patchelf  # [linux]
+        # We need objdump on linux from binutils:
+        # test-rpath.sh: line 16: objdump: command not found
+        - binutils  # [linux]
       files:
         - test-rpath.sh
       commands:

--- a/recipe/test-rpath.sh
+++ b/recipe/test-rpath.sh
@@ -2,7 +2,14 @@
 
 [[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
 [[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
-[[ ${target_platform} == "linux-aarch64" ]] && targetsDir="targets/sbsa-linux"
+# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html?highlight=tegra#cross-compilation
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "sbsa" ]] && targetsDir="targets/sbsa-linux"
+[[ ${target_platform} == "linux-aarch64" && ${arm_variant_type} == "tegra" ]] && targetsDir="targets/aarch64-linux"
+
+if [ -z "${targetsDir+x}" ]; then
+    echo "target_platform: ${target_platform} is unknown! targetsDir must be defined!" >&2
+    exit 1
+fi
 
 errors=""
 

--- a/recipe/test-rpath.sh
+++ b/recipe/test-rpath.sh
@@ -20,7 +20,7 @@ for lib in `find ${PREFIX}/${targetsDir}/lib -type f`; do
     echo "$lib rpath: $rpath"
     if [[ $rpath != "\$ORIGIN" ]]; then
         errors+="$lib\n"
-    elif command -v objdump >/dev/null 2>&1 && [[ $(objdump -x ${lib} | grep "PATH") == *"RUNPATH"* ]]; then
+    elif [[ $(objdump -x ${lib} | grep "PATH") == *"RUNPATH"* ]]; then
         errors+="$lib\n"
     fi
 done

--- a/recipe/test-rpath.sh
+++ b/recipe/test-rpath.sh
@@ -13,7 +13,7 @@ for lib in `find ${PREFIX}/${targetsDir}/lib -type f`; do
     echo "$lib rpath: $rpath"
     if [[ $rpath != "\$ORIGIN" ]]; then
         errors+="$lib\n"
-    elif [[ $(objdump -x ${lib} | grep "PATH") == *"RUNPATH"* ]]; then
+    elif command -v objdump >/dev/null 2>&1 && [[ $(objdump -x ${lib} | grep "PATH") == *"RUNPATH"* ]]; then
         errors+="$lib\n"
     fi
 done


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Epic](https://anaconda.atlassian.net/browse/PKG-5090)
- [PKG-7183](https://anaconda.atlassian.net/browse/PKG-7183)
- [Upstream source](https://developer.download.nvidia.com/compute/cuda/redist/)
- Docs:
  - https://developer.nvidia.com/cuda-12-8-1-download-archive 
  - https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html 
  - https://docs.nvidia.com/cuda/index.html 
  - https://docs.nvidia.com/cuda/cuda-quick-start-guide/index.html 
  - https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html 
  - https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html 

### Explanation of changes:

- Added abs.yaml configuration: Use GLIBC 2.28 (main-rockylinux-8), and custom upload settings for internal testing
- Fixed ARM architecture support:
  - Updated build and test scripts to properly handle different ARM variants (sbsa vs tegra)
  - Added conditional logic for target directory selection based on arm_variant_type
  - Disabled tegra support due to GLIBC version requirements (requires glibc >=2.29)
- Enhanced build requirements:
  - Added binutils dependency for objdump command in test scripts
  - Added GLIBC compatibility check with check-glibc command
- Improved test robustness:
  - Made test-rpath.sh more robust by checking for objdump availability before use
  - Added error handling for undefined target platforms

### Notes:

- Sync with conda-forge upstream/main for CUDA 12.8/12.8.1:
  - :arrows_counterclockwise: **Sync Strategy**: Upstream rebase/merge
  - :package: **Staging Channel**: sk_test
  - :wrench: **Specific version Changes**: Includes CUDA versions up to 12.8/12.8.1 commits
  - :warning: **Note**: This PR contains upstream changes and staging configuration.
  - An AI tool has been used for generating this PR.

[PKG-7183]: https://anaconda.atlassian.net/browse/PKG-7183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ